### PR TITLE
feat: allow manual transaction cancelling with custom error return type

### DIFF
--- a/fast-stm/src/result.rs
+++ b/fast-stm/src/result.rs
@@ -20,7 +20,7 @@ pub enum StmError {
 ///
 /// For the later case, there is the `transaction.or(action1, action2)`, that
 /// is safe to use.
-pub type StmResult<T> = Result<T, StmError>;
+pub type StmResult<T> = Result<T, StmError>; // TODO: rename to StmClosureResult
 
 #[derive(Eq, PartialEq, Clone, Copy, Debug, thiserror::Error)]
 pub enum TransactionError<E> {
@@ -32,11 +32,125 @@ pub enum TransactionError<E> {
     Abort(E),
 }
 
-/// Result of a transaction with failure potential
+/// Result of a transaction body with potential failure.
 pub type TransactionClosureResult<T, E> = Result<T, TransactionError<E>>;
 
+/// Result of a transaction.
+///
+/// A given transaction can finish in three different ways:
+/// - it is validated, and possibly returns an output value,
+/// - it is manually cancelled, and possibly returns a user-defined error,
+/// - it is cancelled through regular STM control flow.
+///
+/// Each variant of this enum represents a case. All of the associated methods behave
+/// like their equivalent for [`std::result::Result`].
+#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[must_use = "this `TransactionResult` may model an error, which should be handled"]
 pub enum TransactionResult<T, E> {
+    /// Transaction completed successfully.
     Validated(T),
-    Aborted(E),
+    /// Transaction was manually aborted.
+    Cancelled(E),
+    /// Transaction was aborted.
     Failed,
+}
+
+impl<T, E> TransactionResult<T, E> {
+    pub fn is_validated(&self) -> bool {
+        matches!(self, Self::Validated(_))
+    }
+
+    pub fn is_validated_and(self, f: impl FnOnce(T) -> bool) -> bool {
+        match self {
+            Self::Validated(t) => f(t),
+            Self::Cancelled(_) | Self::Failed => false,
+        }
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        matches!(self, Self::Cancelled(_))
+    }
+
+    pub fn is_cancelled_and(self, f: impl FnOnce(E) -> bool) -> bool {
+        match self {
+            Self::Cancelled(e) => f(e),
+            Self::Validated(_) | Self::Failed => false,
+        }
+    }
+
+    pub fn validated(self) -> Option<T> {
+        match self {
+            Self::Validated(t) => Some(t),
+            Self::Cancelled(_) | Self::Failed => None,
+        }
+    }
+
+    pub fn cancelled(self) -> Option<E> {
+        match self {
+            Self::Cancelled(e) => Some(e),
+            Self::Validated(_) | Self::Failed => None,
+        }
+    }
+
+    pub fn failed(self) -> bool {
+        matches!(self, Self::Failed)
+    }
+
+    pub fn expect(self, msg: &str) -> T
+    where
+        E: std::fmt::Debug,
+    {
+        match self {
+            Self::Validated(t) => t,
+            Self::Cancelled(e) => panic!("{msg}: {e:?}"),
+            Self::Failed => panic!("{msg}"),
+        }
+    }
+
+    pub fn expect_err(self, msg: &str) -> E
+    where
+        T: std::fmt::Debug,
+    {
+        match self {
+            Self::Validated(t) => panic!("{msg}: {t:?}"),
+            Self::Cancelled(e) => e,
+            Self::Failed => panic!("{msg}"),
+        }
+    }
+
+    pub fn unwrap(self) -> T
+    where
+        E: std::fmt::Debug,
+    {
+        match self {
+            Self::Validated(t) => t,
+            Self::Cancelled(e) => {
+                panic!("called `TransactionResult::unwrap()` on a `Cancelled` value: {e:?}")
+            }
+            Self::Failed => panic!("called `TransactionResult::unwrap()` on a `Failed` value"),
+        }
+    }
+
+    pub fn unwrap_err(self) -> E
+    where
+        T: std::fmt::Debug,
+    {
+        match self {
+            Self::Validated(t) => {
+                panic!("called `TransactionResult::unwrap_err()` on a `Validated` value: {t:?}")
+            }
+            Self::Cancelled(e) => e,
+            Self::Failed => panic!("called `TransactionResult::unwrap_err()` on a `Failed` value"),
+        }
+    }
+
+    pub fn unwrap_or_default(self) -> T
+    where
+        T: Default,
+    {
+        match self {
+            Self::Validated(t) => t,
+            Self::Cancelled(_) | Self::Failed => Default::default(),
+        }
+    }
 }

--- a/fast-stm/src/result.rs
+++ b/fast-stm/src/result.rs
@@ -21,3 +21,16 @@ pub enum StmError {
 /// For the later case, there is the `transaction.or(action1, action2)`, that
 /// is safe to use.
 pub type StmResult<T> = Result<T, StmError>;
+
+#[derive(Eq, PartialEq, Clone, Copy, Debug, thiserror::Error)]
+pub enum TransactionError<E> {
+    /// Failed due to [`StmError`].
+    Stm(#[from] StmError),
+    /// `abort` was called.
+    ///
+    /// The transaction will be aborted and the error returned.
+    Abort(E),
+}
+
+/// Result of a transaction with failure potential
+pub type TransactionResult<T, E> = Result<T, TransactionError<E>>;

--- a/fast-stm/src/result.rs
+++ b/fast-stm/src/result.rs
@@ -33,4 +33,10 @@ pub enum TransactionError<E> {
 }
 
 /// Result of a transaction with failure potential
-pub type TransactionResult<T, E> = Result<T, TransactionError<E>>;
+pub type TransactionClosureResult<T, E> = Result<T, TransactionError<E>>;
+
+pub enum TransactionResult<T, E> {
+    Validated(T),
+    Aborted(E),
+    Failed,
+}

--- a/fast-stm/src/transaction/mod.rs
+++ b/fast-stm/src/transaction/mod.rs
@@ -8,6 +8,8 @@ use std::collections::BTreeMap;
 use std::mem;
 use std::sync::Arc;
 
+use crate::{TransactionClosureResult, TransactionError, TransactionResult};
+
 use self::control_block::ControlBlock;
 use self::log_var::LogVar;
 use super::result::{StmError, StmResult};
@@ -123,6 +125,107 @@ impl Transaction {
                     // on retry wait for changes
                     if let StmError::Retry = e {
                         transaction.wait_for_change();
+                    }
+                }
+            }
+
+            // clear log before retrying computation
+            transaction.clear();
+        }
+    }
+
+    /// Run a function with a transaction.
+    ///
+    /// The transaction will be retried until:
+    /// - it is validated, or
+    /// - it is explicitly aborted from the function, using the `TODO` function.
+    pub fn with_err<T, F, E>(f: F) -> Result<T, E>
+    where
+        F: Fn(&mut Transaction) -> TransactionClosureResult<T, E>,
+    {
+        let _guard = TransactionGuard::new();
+
+        // create a log guard for initializing and cleaning up
+        // the log
+        let mut transaction = Transaction::new();
+
+        // loop until success
+        loop {
+            // run the computation
+            match f(&mut transaction) {
+                // on success exit loop
+                Ok(t) => {
+                    if transaction.commit() {
+                        return Ok(t);
+                    }
+                }
+                // on error,
+                Err(e) => match e {
+                    // abort and return the error
+                    TransactionError::Abort(err) => return Err(err),
+                    // retry
+                    TransactionError::Stm(_) => {
+                        transaction.wait_for_change();
+                    }
+                },
+            }
+
+            // clear log before retrying computation
+            transaction.clear();
+        }
+    }
+
+    /// Run a function with a transaction.
+    ///
+    /// `with_control` takes another control function, that
+    /// can steer the control flow and possible terminate early.
+    ///
+    /// `control` can react to counters, timeouts or external inputs.
+    ///
+    /// It allows the user to fall back to another strategy, like a global lock
+    /// in the case of too much contention.
+    ///
+    /// Please not, that the transaction may still infinitely wait for changes when `retry` is
+    /// called and `control` does not abort.
+    /// If you need a timeout, another thread should signal this through a [`TVar`].
+    pub fn with_control_and_err<T, F, C, E>(mut control: C, f: F) -> TransactionResult<T, E>
+    where
+        F: Fn(&mut Transaction) -> TransactionClosureResult<T, E>,
+        C: FnMut(StmError) -> TransactionControl,
+    {
+        let _guard = TransactionGuard::new();
+
+        // create a log guard for initializing and cleaning up
+        // the log
+        let mut transaction = Transaction::new();
+
+        // loop until success
+        loop {
+            // run the computation
+            match f(&mut transaction) {
+                // on success exit loop
+                Ok(t) => {
+                    if transaction.commit() {
+                        return TransactionResult::Validated(t);
+                    }
+                }
+
+                Err(e) => {
+                    match e {
+                        TransactionError::Abort(err) => {
+                            return TransactionResult::Aborted(err);
+                        }
+                        TransactionError::Stm(err) => {
+                            // Check if the user wants to abort the transaction.
+                            if let TransactionControl::Abort = control(err) {
+                                return TransactionResult::Failed;
+                            }
+
+                            // on retry wait for changes
+                            if let StmError::Retry = err {
+                                transaction.wait_for_change();
+                            }
+                        }
                     }
                 }
             }

--- a/fast-stm/src/transaction/mod.rs
+++ b/fast-stm/src/transaction/mod.rs
@@ -213,7 +213,7 @@ impl Transaction {
                 Err(e) => {
                     match e {
                         TransactionError::Abort(err) => {
-                            return TransactionResult::Aborted(err);
+                            return TransactionResult::Cancelled(err);
                         }
                         TransactionError::Stm(err) => {
                             // Check if the user wants to abort the transaction.


### PR DESCRIPTION
add all necessary mechanisms to integrate custom errors in transaction control flow. this includes:

- new error and result types:
	- `TransactionError<E>`: enum with two variants, one to wrap regular `StmError`s, one for user-defined errors
	- `TransactionClosureResult<T, E>`: a type alias for the new closure return type (= `Result<T, TransactionError<E>>`)
	- `TransactionResult<T, E>`: new enum with three variants, for when transaction is validated, aborted with an error, or aborted through control flow.
- two new transaction constructor/runner:
	- `Transaction::with_err`: will retry until validated or manually aborted
	- `Transaction::with_err_and_control`: allows specification of the control flow in case of regular `StmError`s, and manual abortion like above
- an `abort(e: E)` function for readability in user code