### PR TITLE
feat: implement early read inconsistency check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build_crates:
-    name: Build crates for ${{ matrix.os }}
+  build_all_feats:
+    name: Build for ${{ matrix.os }} (all features)
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
@@ -22,10 +22,9 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Build main crate
-        run: cargo build -p fast-stm
-  build_examples:
-    name: Build examples for ${{ matrix.os }}
+      - run: cargo build --all-targets --all-features
+  build_no_feats:
+    name: Build for ${{ matrix.os }} (no features)
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
@@ -36,19 +35,4 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Build examples
-        run: cargo build --examples
-  build_benchmarks:
-    name: Build benchmarks for ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          submodules: recursive
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Build benchmarks
-        run: cargo build --benches
+      - run: cargo build --all-targets --no-default-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
@@ -31,7 +31,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
@@ -45,7 +45,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -23,8 +23,7 @@ jobs:
       - name: Generate documentation
         run: |
           cargo +nightly doc --all --all-features --no-deps
-          sudo chmod +x docs/build.sh
-          sudo ./docs/build.sh
+          sh ./docs/build.sh
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
   publish:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run Clippy
-        run: cargo clippy --all --all-features
+        run: cargo clippy --all-targets --all-features
   clippy-no-feat:
     runs-on: ubuntu-22.04
     steps:
@@ -39,7 +39,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run Clippy
-        run: cargo clippy --all
+        run: cargo clippy --all-targets --no-default-features
   tests:
     runs-on: ubuntu-22.04
     steps:
@@ -49,4 +49,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run Tests
-        run: cargo test --all --all-features
+        run: cargo test --all-targets --all-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   format:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
@@ -23,7 +23,7 @@ jobs:
   clippy:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
@@ -33,7 +33,7 @@ jobs:
   clippy-no-feat:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
@@ -43,7 +43,7 @@ jobs:
   tests:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ fast-stm = { version = "0.5.0", path = "./fast-stm" }
 
 # external
 parking_lot = { version = "0.12.3", default-features = false }
+rustversion = "1.0.18"
 thiserror = "2.0.11"
 
 # benchmarks

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,6 @@
 [workspace]
 resolver = "2"
-members = [
-    "fast-stm",
-    "benches"
-]
+members = ["fast-stm", "benches"]
 
 [workspace.package]
 version = "0.5.0"
@@ -19,8 +16,8 @@ Performance-focused implementation of software transactional memory.
 Allows composable atomic operations.
 """
 authors = [
-    "Isaie Muron <github@imrn.fr>",
-    "Marthog <Marthog@users.noreply.github.com>"
+  "Isaie Muron <github@imrn.fr>",
+  "Marthog <Marthog@users.noreply.github.com>",
 ]
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,9 @@ authors = [
 fast-stm = { version = "0.5.0", path = "./fast-stm" }
 
 # external
+cfg-if = "1.0.4"
 parking_lot = { version = "0.12.3", default-features = false }
+rustc-hash = "2.1.1"
 rustversion = "1.0.18"
 thiserror = "2.0.11"
 

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -31,4 +31,3 @@ harness = false
 name = "store-time"
 path = "benches/store.rs"
 harness = false
-

--- a/fast-stm/Cargo.toml
+++ b/fast-stm/Cargo.toml
@@ -13,10 +13,14 @@ authors.workspace = true
 
 [features]
 default = ["wait-on-retry"]
+
+hash-registers = ["dep:rustc-hash"]
 wait-on-retry = []
 
 [dependencies]
+cfg-if = { workspace = true }
 parking_lot = { workspace = true }
+rustc-hash = { workspace = true, optional = true }
 thiserror = { workspace = true }
 
 [build-dependencies]

--- a/fast-stm/Cargo.toml
+++ b/fast-stm/Cargo.toml
@@ -18,3 +18,6 @@ wait-on-retry = []
 [dependencies]
 parking_lot = { workspace = true }
 thiserror = { workspace = true }
+
+[build-dependencies]
+rustversion.workspace = true

--- a/fast-stm/Cargo.toml
+++ b/fast-stm/Cargo.toml
@@ -11,7 +11,10 @@ keywords.workspace = true
 description.workspace = true
 authors.workspace = true
 
+[features]
+default = ["wait-on-retry"]
+wait-on-retry = []
+
 [dependencies]
 parking_lot = { workspace = true }
 thiserror = { workspace = true }
-

--- a/fast-stm/build.rs
+++ b/fast-stm/build.rs
@@ -1,0 +1,18 @@
+#[rustversion::nightly]
+fn set_rustc_channel_cfg() -> &'static str {
+    "nightly"
+}
+
+#[rustversion::beta]
+fn set_rustc_channel_cfg() -> &'static str {
+    "beta"
+}
+
+#[rustversion::stable]
+fn set_rustc_channel_cfg() -> &'static str {
+    "stable"
+}
+
+fn main() {
+    println!("cargo:rustc-cfg={}", set_rustc_channel_cfg());
+}

--- a/fast-stm/src/lib.rs
+++ b/fast-stm/src/lib.rs
@@ -107,6 +107,9 @@
 //! keep the amount of accessed variables as low as needed.
 //!
 
+// document features
+#![allow(unexpected_cfgs)]
+#![cfg_attr(nightly, feature(doc_cfg))]
 // Extra linting with exceptions
 #![warn(clippy::pedantic)]
 #![allow(clippy::missing_errors_doc)]

--- a/fast-stm/src/transaction/log_var.rs
+++ b/fast-stm/src/transaction/log_var.rs
@@ -65,7 +65,7 @@ impl LogVar {
                 val = v.clone();
                 this = Self::Read(v.clone());
             }
-        };
+        }
         *self = this;
         val
     }

--- a/fast-stm/src/transaction/mod.rs
+++ b/fast-stm/src/transaction/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "wait-on-retry")]
 pub mod control_block;
 pub mod log_var;
 
@@ -10,6 +11,7 @@ use std::sync::Arc;
 
 use crate::{TransactionClosureResult, TransactionError, TransactionResult};
 
+#[cfg(feature = "wait-on-retry")]
 use self::control_block::ControlBlock;
 use self::log_var::LogVar;
 use super::result::{StmClosureResult, StmError};
@@ -123,6 +125,7 @@ impl Transaction {
                     }
 
                     // on retry wait for changes
+                    #[cfg(feature = "wait-on-retry")]
                     if let StmError::Retry = e {
                         transaction.wait_for_change();
                     }
@@ -165,6 +168,7 @@ impl Transaction {
                     TransactionError::Abort(err) => return Err(err),
                     // retry
                     TransactionError::Stm(_) => {
+                        #[cfg(feature = "wait-on-retry")]
                         transaction.wait_for_change();
                     }
                 },
@@ -222,6 +226,7 @@ impl Transaction {
                             }
 
                             // on retry wait for changes
+                            #[cfg(feature = "wait-on-retry")]
                             if let StmError::Retry = err {
                                 transaction.wait_for_change();
                             }
@@ -374,6 +379,7 @@ impl Transaction {
 
     /// Wait for any variable to change,
     /// because the change may lead to a new calculation result.
+    #[cfg(feature = "wait-on-retry")]
     fn wait_for_change(&mut self) {
         // Create control block for waiting.
         let ctrl = Arc::new(ControlBlock::new());
@@ -486,6 +492,7 @@ impl Transaction {
             *lock = value.clone();
         }
 
+        #[cfg(feature = "wait-on-retry")]
         for var in written {
             // Unblock all threads waiting for it.
             var.wake_all();

--- a/fast-stm/src/transaction/mod.rs
+++ b/fast-stm/src/transaction/mod.rs
@@ -257,7 +257,17 @@ impl Transaction {
         // Check if the same var was written before.
         let value = match self.vars.entry(ctrl) {
             // If the variable has been accessed before, then load that value.
-            Entry::Occupied(mut entry) => entry.get_mut().read(),
+            Entry::Occupied(mut entry) => {
+                let log = entry.get_mut();
+                // if we previously read the var, check for value change
+                if let LogVar::Read(v) = log {
+                    let crt_v = var.read_ref_atomic();
+                    if !Arc::ptr_eq(&v, &crt_v) {
+                        return Err(StmError::Failure);
+                    }
+                }
+                log.read()
+            }
 
             // Else load the variable statically.
             Entry::Vacant(entry) => {

--- a/fast-stm/src/transaction/mod.rs
+++ b/fast-stm/src/transaction/mod.rs
@@ -4,10 +4,22 @@ pub mod log_var;
 
 use std::any::Any;
 use std::cell::Cell;
-use std::collections::btree_map::Entry;
-use std::collections::BTreeMap;
+// #[cfg(feature = "hash-registers")]
+// use std::collections::hash_map::Entry;
+// #[cfg(not(feature = "hash-registers"))]
+// use std::collections::{btree_map::Entry, BTreeMap};
+cfg_if::cfg_if! {
+    if #[cfg(feature = "hash-registers")] {
+        use std::collections::hash_map::Entry;
+    } else {
+        use std::collections::{btree_map::Entry, BTreeMap};
+    }
+}
 use std::mem;
 use std::sync::Arc;
+
+#[cfg(feature = "hash-registers")]
+use rustc_hash::FxHashMap;
 
 use crate::{TransactionClosureResult, TransactionError, TransactionResult};
 
@@ -56,7 +68,10 @@ pub struct Transaction {
     /// The `VarControlBlock` is unique because it uses it's address for comparing.
     ///
     /// The logs need to be accessed in a order to prevend dead-locks on locking.
+    #[cfg(not(feature = "hash-registers"))]
     vars: BTreeMap<Arc<VarControlBlock>, LogVar>,
+    #[cfg(feature = "hash-registers")]
+    vars: FxHashMap<*const VarControlBlock, LogVar>,
 }
 
 impl Transaction {
@@ -66,7 +81,10 @@ impl Transaction {
     /// Use `atomically` instead.
     fn new() -> Transaction {
         Transaction {
+            #[cfg(not(feature = "hash-registers"))]
             vars: BTreeMap::new(),
+            #[cfg(feature = "hash-registers")]
+            vars: FxHashMap::default(),
         }
     }
 
@@ -260,7 +278,11 @@ impl Transaction {
     pub fn read<T: Send + Sync + Any + Clone>(&mut self, var: &TVar<T>) -> StmClosureResult<T> {
         let ctrl = var.control_block().clone();
         // Check if the same var was written before.
-        let value = match self.vars.entry(ctrl) {
+        #[cfg(not(feature = "hash-registers"))]
+        let key = ctrl;
+        #[cfg(feature = "hash-registers")]
+        let key = Arc::as_ptr(&ctrl);
+        let value = match self.vars.entry(key) {
             // If the variable has been accessed before, then load that value.
             Entry::Occupied(mut entry) => {
                 let log = entry.get_mut();
@@ -304,7 +326,11 @@ impl Transaction {
         // new control block
         let ctrl = var.control_block().clone();
         // update or create new entry
-        match self.vars.entry(ctrl) {
+        #[cfg(not(feature = "hash-registers"))]
+        let key = ctrl;
+        #[cfg(feature = "hash-registers")]
+        let key = Arc::as_ptr(&ctrl);
+        match self.vars.entry(key) {
             Entry::Occupied(mut entry) => entry.get_mut().write(boxed),
             Entry::Vacant(entry) => {
                 entry.insert(LogVar::Write(boxed));
@@ -393,6 +419,8 @@ impl Transaction {
             .filter_map(|(a, b)| b.into_read_value().map(|b| (a, b)))
             // Check for consistency.
             .all(|(var, value)| {
+                #[cfg(feature = "hash-registers")]
+                let var = unsafe { var.as_ref() }.expect("E: unreachabel");
                 var.wait(&ctrl);
                 let x = {
                     // Take read lock and read value.
@@ -438,8 +466,19 @@ impl Transaction {
         // vector of written variables
         let mut written = Vec::with_capacity(self.vars.len());
 
-        for (var, value) in &self.vars {
+        #[cfg(feature = "hash-registers")]
+        let records = {
+            let mut recs: Vec<_> = self.vars.iter().collect();
+            recs.sort_by(|(k1, _), (k2, _)| k1.cmp(&k2));
+            recs
+        };
+        #[cfg(not(feature = "hash-registers"))]
+        let records = &self.vars;
+
+        for (var, value) in records {
             // lock the variable and read the value
+            #[cfg(feature = "hash-registers")]
+            let var = unsafe { var.as_ref() }.expect("E: unreachabel");
 
             match *value {
                 // We need to take a write lock.


### PR DESCRIPTION
fixes #13

It would probably be a good idea to make a second implementation, without the early check and without the returned `Result`s that were useless in the first place; I'm not sure those were optimized away and it would make for a lighter API.