### PR TITLE
implement early read inconsistency check and dedicated feature

### DIFF
--- a/fast-stm/Cargo.toml
+++ b/fast-stm/Cargo.toml
@@ -14,6 +14,7 @@ authors.workspace = true
 [features]
 default = ["wait-on-retry"]
 
+early-conflict-detection = []
 hash-registers = ["dep:rustc-hash"]
 wait-on-retry = []
 


### PR DESCRIPTION
fix #13

I plan on creating a second crate (`light-stm`?) where this check isn't implemented and the results are removed from the API.

the check can be enabled with the `early-conflict-detection` feature