### PR TITLE
feat: add `light-stm` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["fast-stm", "benches"]
+members = ["fast-stm", "light-stm", "benches"]
 
 [workspace.package]
 version = "0.6.0"
@@ -23,6 +23,7 @@ authors = [
 [workspace.dependencies]
 # members
 fast-stm = { version = "0.6.0", path = "./fast-stm" }
+light-stm = { version = "0.6.0", path = "./light-stm" }
 
 # external
 cfg-if = "1.0.4"

--- a/light-stm/Cargo.toml
+++ b/light-stm/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "light-stm"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+readme.workspace = true
+categories.workspace = true
+keywords.workspace = true
+description.workspace = true
+authors.workspace = true
+
+[features]
+hash-registers = ["dep:rustc-hash"]
+
+[dependencies]
+cfg-if = { workspace = true }
+parking_lot = { workspace = true }
+rustc-hash = { workspace = true, optional = true }
+thiserror = { workspace = true }
+
+[build-dependencies]
+rustversion.workspace = true

--- a/light-stm/build.rs
+++ b/light-stm/build.rs
@@ -1,0 +1,18 @@
+#[rustversion::nightly]
+fn set_rustc_channel_cfg() -> &'static str {
+    "nightly"
+}
+
+#[rustversion::beta]
+fn set_rustc_channel_cfg() -> &'static str {
+    "beta"
+}
+
+#[rustversion::stable]
+fn set_rustc_channel_cfg() -> &'static str {
+    "stable"
+}
+
+fn main() {
+    println!("cargo:rustc-cfg={}", set_rustc_channel_cfg());
+}

--- a/light-stm/src/lib.rs
+++ b/light-stm/src/lib.rs
@@ -1,0 +1,497 @@
+//! This library implements
+//! [software transactional memory](https://en.wikipedia.org/wiki/Software_transactional_memory),
+//! often abbreviated with STM.
+//!
+//! It is designed closely to haskells STM library. Read Simon Marlow's
+//! *Parallel and Concurrent Programming in Haskell*
+//! for more info. Especially the chapter about
+//! Performance is also important for using STM in rust.
+//!
+//! With locks the sequential composition of two
+//! two threadsafe actions is no longer threadsafe because
+//! other threads may interfer in between of these actions.
+//! Applying a third lock to protect both may lead to common sources of errors
+//! like deadlocks or race conditions.
+//!
+//! Unlike locks Software transactional memory is composable.
+//! It is typically implemented by writing all read and write
+//! operations in a log. When the action has finished and
+//! all the used `TVar`s are consistent, the writes are commited as
+//! a single atomic operation.
+//! Otherwise the computation repeats. This may lead to starvation,
+//! but avoids common sources of bugs.
+//!
+//! Panicing within STM does not poison the `TVar`s. STM ensures consistency by
+//! never committing on panic.
+//!
+//! # Features
+//!
+//! The `hash-registers` feature can be enabled to use a `HashMap`-based implementation of
+//! transaction registers instead of a `BTreeMap`-based implementation
+//!
+//! - this may lead to improved performance if your transactions are longer / read-heavy, due to
+//!   lookup computational complexity
+//! - the hash algorithm is provided by the `rustc-hash` crate, not the `std`
+//!
+//! # Usage
+//!
+//! You should only use the functions that are transaction-safe.
+//! Transaction-safe functions don't have side effects, except those provided by `TVar`.
+//! Mutexes and other blocking mechanisms are especially dangerous, because they can
+//! interfere with the internal locking scheme of the transaction and therefore
+//! cause deadlocks.
+//!
+//! Note, that Transaction-safety does *not* mean safety in the rust sense, but is a
+//! subset of allowed behavior. Even if code is not transaction-safe, no segmentation
+//! faults will happen.
+//!
+//! You can run the top-level atomic operation by calling `atomically`.
+//!
+//!
+//! ```
+//! # use fast_stm::atomically;
+//! atomically(|trans| {
+//!     // some action
+//!     // return value as `Result`, for example
+//!     Ok(42)
+//! });
+//! ```
+//!
+//! Nested calls to `atomically` are not allowed. A run-time check prevents this.
+//! Instead of using atomically internally, add a `&mut Transaction` parameter and
+//! return `StmResult`.
+//!
+//! Use ? on `StmResult`, to propagate a transaction error through the system.
+//! Do not handle the error yourself.
+//!
+//! ```
+//! # use fast_stm::{atomically, TVar};
+//! let var = TVar::new(0);
+//!
+//! let x = atomically(|trans| {
+//!     var.write(trans, 42)?; // Pass failure to parent.
+//!     var.read(trans) // Return the value saved in var.
+//! });
+//!
+//! println!("var = {}", x);
+//! // var = 42
+//!
+//! ```
+//!
+//! # Transaction safety
+//!
+//! Software transactional memory is completely safe in the rust sense, so undefined behavior
+//! will never occur. Still there are multiple rules that you should obey when dealing with
+//! software transactional memory.
+//!
+//! * Don't run code with side effects, especially no IO-code.
+//!   Transactions repeat in failure cases. Using IO would repeat this IO-code.
+//!   Return a closure if you have to.
+//! * Don't handle `StmClosureResult`/`StmFallibleClosureResult` yourself.
+//!   Use `Transaction::or` to combine alternative paths and `optionally` to check if an inner
+//!   function has failed. Always use `?`.
+//! * Don't run `atomically` inside of another. `atomically` is designed to have side effects
+//!   and will therefore break transaction safety.
+//!   Nested calls are detected at runtime and handled with panicking.
+//!   When you use STM in the inner of a function, then
+//!   express it in the public interface, by taking `&mut Transaction` as parameter and
+//!   returning `StmResult<T>`. Callers can safely compose it into
+//!   larger blocks.
+//! * Don't mix locks and transactions. Your code will easily deadlock or slow
+//!   down unpredictably.
+//! * Don't use inner mutability to change the content of a `TVar`.
+//!
+//! Panicking in a transaction is transaction-safe. The transaction aborts and
+//! all changes are discarded. No poisoning or half written transactions happen.
+//!
+//! # Speed
+//!
+//! Generally keep your atomic blocks as small as possible, because
+//! the more time you spend, the more likely it is, to collide with
+//! other threads. For STM, reading `TVar`s is quite slow, because it
+//! needs to look them up in the log every time.
+//! Every used `TVar` increases the chance of collisions. Therefore you should
+//! keep the amount of accessed variables as low as needed. Longer transactions
+//! can benefit from the `hash-registers` feature due to the `O(1)` look-up
+//! complexity (vs `O(log(n))`).
+
+// document features
+#![allow(unexpected_cfgs)]
+#![cfg_attr(nightly, feature(doc_cfg))]
+// Extra linting with exceptions
+#![warn(clippy::pedantic)]
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::must_use_candidate)]
+#![allow(clippy::should_panic_without_expect)]
+
+extern crate parking_lot;
+
+mod result;
+mod transaction;
+mod tvar;
+
+#[cfg(test)]
+mod test;
+
+pub use result::*;
+pub use transaction::Transaction;
+pub use transaction::TransactionControl;
+pub use tvar::TVar;
+
+/// Convert a `StmClosureResult<T, E_A>` to `StmClosureResult<T, E_B>`.
+///
+/// This macro is used to cleanly write transactions where multiple kind of errors are
+/// possible during execution. The macro will not fail as long as the specified target
+/// error `$to` implements `From<E>`, `E` being the error possibly returned by `$op`.
+/// It expands to:
+///
+/// ```ignore
+/// $op.map_err(|e| match e {
+///         $crate::StmError::Abort(e) => $crate::StmError::Abort($to::from(e)),
+///         $crate::StmError::Stm(e) => $crate::StmError::Stm(e),
+///     })?
+/// ```
+///
+/// # Example
+///
+/// ```rust
+/// # use fast_stm::{abort, atomically_with_err, try_or_coerce, Transaction, StmFallibleClosureResult};
+///
+/// struct Error1;
+/// struct Error2;
+///
+/// impl From<Error1> for Error2 {
+///     fn from(e: Error1) -> Self {
+///         Error2
+///     }
+/// }
+///
+/// fn op1(trans: &mut Transaction) -> StmFallibleClosureResult<(), Error1> {
+///     // ...
+///     Ok(())
+/// }
+///
+/// fn op2(trans: &mut Transaction) -> StmFallibleClosureResult<(), Error2> {
+///     // ...
+///     Ok(())
+/// }
+///
+/// let res: Result<(), Error2> = atomically_with_err(|trans| {
+///     try_or_coerce!(op1(trans), Error2);
+///     op2(trans)?;   
+///     Ok(())
+/// });
+/// ```
+#[macro_export]
+macro_rules! try_or_coerce {
+    ($op: expr, $to: ident) => {
+        $op.map_err(|e| match e {
+            $crate::StmError::Abort(e) => $crate::StmError::Abort($to::from(e)),
+            $crate::StmError::Retry(e) => $crate::StmError::Retry(e),
+        })?
+    };
+}
+
+/// Explicitly `retry` a transaction.
+#[macro_export]
+macro_rules! retry {
+    () => {
+        return Err($crate::RetrySignal("no specified information"))?
+    };
+    ($msg: literal) => {
+        return Err($crate::RetrySignal($msg))?
+    };
+}
+
+/// Explicitly `abort` a transaction.
+#[macro_export]
+macro_rules! abort {
+    ($err: expr) => {
+        return Err($crate::AbortSignal($err))?
+    };
+}
+
+/// Run a function atomically by using Software Transactional Memory.
+///
+/// It calls to `Transaction::with` internally, but is more explicit.
+pub fn atomically<T, F>(f: F) -> T
+where
+    F: Fn(&mut Transaction) -> StmClosureResult<T>,
+{
+    Transaction::with(f)
+}
+
+/// Run a function atomically by using Software Transactional Memory.
+///
+/// It calls to `Transaction::with_err` internally, but is more explicit.
+pub fn atomically_with_err<T, E, F>(f: F) -> Result<T, E>
+where
+    F: Fn(&mut Transaction) -> StmFallibleClosureResult<T, E>,
+{
+    Transaction::with_err(f)
+}
+
+#[inline]
+/// Unwrap `Option` or call retry if it is `None`.
+///
+/// `optionally` is the inverse of `unwrap_or_retry`.
+///
+/// # Example
+///
+/// ```
+/// # use fast_stm::*;
+/// let x = TVar::new(Some(42));
+///
+/// atomically(|tx| {
+///         let inner = unwrap_or_retry(x.read(tx)?)?;
+///         assert_eq!(inner, 42); // inner is always 42.
+///         Ok(inner)
+///     }
+/// );
+/// ```
+pub fn unwrap_or_retry<T>(option: Option<T>) -> StmClosureResult<T> {
+    match option {
+        Some(x) => Ok(x),
+        None => retry!("`unwrap_or_retry` called on `None` value"),
+    }
+}
+
+#[inline]
+/// Retry until `cond` is true.
+///
+/// # Example
+///
+/// ```
+/// # use fast_stm::*;
+/// let var = TVar::new(42);
+///
+/// let x = atomically(|tx| {
+///     let v = var.read(tx)?;
+///     guard(v==42)?;
+///     // v is now always 42.
+///     Ok(v)
+/// });
+/// assert_eq!(x, 42);
+/// ```
+pub fn guard(cond: bool) -> StmClosureResult<()> {
+    if cond {
+        Ok(())
+    } else {
+        retry!()
+    }
+}
+
+#[inline]
+/// Optionally run a transaction `f`. If `f` fails with a `retry()`, it does
+/// not cancel the whole transaction, but returns `None`.
+///
+/// Note that `optionally` does not always recover the function, if
+/// inconsistencies where found.
+///
+/// `unwrap_or_retry` is the inverse of `optionally`.
+///
+/// # Example
+///
+/// ```
+/// # use fast_stm::*;
+/// let x:Option<i32> = atomically(|tx|
+///     optionally(tx, |_| retry()));
+/// assert_eq!(x, None);
+/// ```
+pub fn optionally<T, F>(tx: &mut Transaction, f: F) -> StmClosureResult<Option<T>>
+where
+    F: Fn(&mut Transaction) -> StmClosureResult<T>,
+{
+    tx.or(|t| f(t).map(Some), |_| Ok(None))
+}
+
+#[cfg(test)]
+mod test_lib {
+    use super::*;
+
+    #[test]
+    fn infinite_retry() {
+        let terminated = test::terminates(300, || {
+            let _infinite_retry: i32 = atomically(|_| retry!());
+        });
+        assert!(!terminated);
+    }
+
+    #[test]
+    fn stm_nested() {
+        let var = TVar::new(0);
+
+        let x = atomically(|tx| {
+            var.write(tx, 42);
+            Ok(var.read(tx))
+        });
+
+        assert_eq!(42, x);
+    }
+
+    /// Run multiple threads.
+    ///
+    /// Thread 1: Read a var, block until it is not 0 and then
+    /// return that value.
+    ///
+    /// Thread 2: Wait a bit. Then write a value.
+    ///
+    /// Check if Thread 1 is woken up correctly and then check for
+    /// correctness.
+    #[test]
+    fn threaded() {
+        use std::thread;
+        use std::time::Duration;
+
+        let var = TVar::new(0);
+        // Clone for other thread.
+        let varc = var.clone();
+
+        let x = test::async_test(
+            800,
+            move || {
+                atomically(|tx| {
+                    let x = varc.read(tx);
+                    if x == 0 {
+                        retry!()
+                    } else {
+                        Ok(x)
+                    }
+                })
+            },
+            || {
+                thread::sleep(Duration::from_millis(100));
+
+                atomically(|tx| Ok(var.write(tx, 42)));
+            },
+        )
+        .unwrap();
+
+        assert_eq!(42, x);
+    }
+
+    /// test if a STM calculation is rerun when a Var changes while executing
+    #[test]
+    fn read_write_interfere() {
+        use std::thread;
+        use std::time::Duration;
+
+        // create var
+        let var = TVar::new(0);
+        let varc = var.clone(); // Clone for other thread.
+
+        // spawn a thread
+        let t = thread::spawn(move || {
+            atomically(|tx| {
+                // read the var
+                let x = varc.read(tx);
+                // ensure that x varc changes in between
+                thread::sleep(Duration::from_millis(500));
+
+                // write back modified data this should only
+                // happen when the value has not changed
+                varc.write(tx, x + 10);
+                Ok(())
+            });
+        });
+
+        // ensure that the thread has started and already read the var
+        thread::sleep(Duration::from_millis(100));
+
+        // now change it
+        atomically(|tx| Ok(var.write(tx, 32)));
+
+        // finish and compare
+        let _ = t.join();
+        assert_eq!(42, var.read_atomic());
+    }
+
+    #[test]
+    fn or_simple() {
+        let var = TVar::new(42);
+
+        let x = atomically(|tx| tx.or(|_| retry!(), |tx| Ok(var.read(tx))));
+
+        assert_eq!(x, 42);
+    }
+
+    /// A variable should not be written,
+    /// when another branch was taken
+    #[test]
+    fn or_nocommit() {
+        let var = TVar::new(42);
+
+        let x = atomically(|tx| {
+            tx.or(
+                |tx| {
+                    var.write(tx, 23);
+                    retry!()
+                },
+                |tx| Ok(var.read(tx)),
+            )
+        });
+
+        assert_eq!(x, 42);
+    }
+
+    #[test]
+    fn or_nested_first() {
+        let var = TVar::new(42);
+
+        let x = atomically(|tx| {
+            tx.or(
+                |tx| tx.or(|_| retry!(), |_| retry!()),
+                |tx| Ok(var.read(tx)),
+            )
+        });
+
+        assert_eq!(x, 42);
+    }
+
+    #[test]
+    fn or_nested_second() {
+        let var = TVar::new(42);
+
+        let x = atomically(|tx| tx.or(|_| retry!(), |t| t.or(|t2| Ok(var.read(t2)), |_| retry!())));
+
+        assert_eq!(x, 42);
+    }
+
+    #[test]
+    fn unwrap_some() {
+        let x = Some(42);
+        let y = atomically(|_| unwrap_or_retry(x));
+        assert_eq!(y, 42);
+    }
+
+    #[test]
+    fn unwrap_none() {
+        let x: Option<i32> = None;
+        assert!(unwrap_or_retry(x).is_err());
+    }
+
+    #[test]
+    fn guard_true() {
+        let x = guard(true);
+        assert_eq!(x, Ok(()));
+    }
+
+    #[test]
+    fn guard_false() {
+        let x = guard(false);
+        assert!(x.is_err());
+    }
+
+    #[test]
+    fn optionally_succeed() {
+        let x = atomically(|t| optionally(t, |_| Ok(42)));
+        assert_eq!(x, Some(42));
+    }
+
+    #[test]
+    fn optionally_fail() {
+        let x: Option<i32> = atomically(|t| optionally(t, |_| retry!()));
+        assert_eq!(x, None);
+    }
+}

--- a/light-stm/src/result.rs
+++ b/light-stm/src/result.rs
@@ -1,0 +1,31 @@
+// regular transaction
+
+/// Error of a single step of a transaction.
+#[derive(Eq, PartialEq, Clone, Copy, Debug, thiserror::Error)]
+pub enum StmError<E> {
+    /// `retry` was called.
+    ///
+    /// It may block until at least one read variable has changed.
+    Retry(#[from] RetrySignal),
+
+    /// Failed due to manual cancelling (e.g. a call to `abort` in the transaction's body).
+    Abort(#[from] AbortSignal<E>),
+}
+
+#[derive(Eq, PartialEq, Clone, Copy, Debug, thiserror::Error)]
+#[error("explicit retry: {0}")]
+pub struct RetrySignal(pub(crate) &'static str);
+
+#[derive(Eq, PartialEq, Clone, Copy, Debug, thiserror::Error)]
+#[error("explicit abort: {0}")]
+pub struct AbortSignal<E>(pub(crate) E);
+
+/// Return type of a non-fallible transaction body.
+///
+/// Transaction of this type may call `retry`, but cannot `abort` with an error.
+pub type StmClosureResult<T> = Result<T, RetrySignal>;
+
+/// Return type of a fallible transaction body.
+///
+/// Transaction of this type may call `retry` and `abort` with an error.
+pub type StmFallibleClosureResult<T, E> = Result<T, StmError<E>>;

--- a/light-stm/src/test.rs
+++ b/light-stm/src/test.rs
@@ -1,0 +1,74 @@
+//! This module contains helpers for various tests.
+//! Quite a lot of tests run operations asynchonously and need to check
+//! for deadlocks. We do this by waiting a certain amount of time for completion.
+//!
+//! This module contains some helpers that simplify other tests.
+
+use std::sync::mpsc::channel;
+use std::thread;
+use std::time::Duration;
+
+/// Check if a function `f` terminates within a given timeframe.
+///
+/// If the function does not terminate, it keeps a thread alive forever,
+/// so don't run too many test (preferable just one) in sequence.
+pub fn terminates<F>(duration_ms: u64, f: F) -> bool
+where
+    F: Send + FnOnce() + 'static,
+{
+    terminates_async(duration_ms, f, || {})
+}
+
+/// Check if a function `f` terminates within a given timeframe,
+/// but run a second function `g` concurrently.
+///
+/// If the function does not terminate, it keeps a thread alive forever,
+/// so don't run too many test (preferable just one) in sequence.
+pub fn terminates_async<F, G>(duration_ms: u64, f: F, g: G) -> bool
+where
+    F: Send + FnOnce() + 'static,
+    G: FnOnce(),
+{
+    async_test(duration_ms, f, g).is_some()
+}
+
+/// Run two functions `f` and `g` concurrently.
+///
+/// Run `f` in a second thread, `g` in the main thread. Wait the given time `duration_ms` for `g`
+/// and return `f`s return value or return `None` if `f` does not terminate.
+///
+/// If `f` does not terminate, it keeps a thread alive forever,
+/// so don't run too many test (preferable just one) in sequence.
+pub fn async_test<T, F, G>(duration_ms: u64, f: F, g: G) -> Option<T>
+where
+    F: Send + FnOnce() -> T + 'static,
+    G: FnOnce(),
+    T: Send + 'static,
+{
+    let (tx, rx) = channel();
+
+    thread::spawn(move || {
+        let t = f();
+        // wakeup other thread
+        let _ = tx.send(t);
+    });
+
+    g();
+
+    if let a @ Some(_) = rx.try_recv().ok() {
+        return a;
+    }
+
+    // Give enough time for travis to get up.
+    // Sleep in 50 ms steps, so that it does not waste too much time if the thread finishes earlier.
+    for _ in 0..duration_ms / 50 {
+        thread::sleep(Duration::from_millis(50));
+        if let a @ Some(_) = rx.try_recv().ok() {
+            return a;
+        }
+    }
+
+    thread::sleep(Duration::from_millis(duration_ms % 50));
+
+    rx.try_recv().ok()
+}

--- a/light-stm/src/transaction/log_var.rs
+++ b/light-stm/src/transaction/log_var.rs
@@ -1,0 +1,110 @@
+use std::any::Any;
+use std::sync::Arc;
+
+pub type ArcAny = Arc<dyn Any + Send + Sync>;
+
+/// `LogVar` is used by `Log` to track which `Var` was either read or written or both.
+/// Depending on the type, STM has to write, ensure consistency or block on this value.
+#[derive(Clone)]
+pub enum LogVar {
+    /// Var has been read.
+    Read(ArcAny),
+
+    /// Var has been written and no dependency on the original exists.
+    ///
+    /// There is no need to check for consistency.
+    Write(ArcAny),
+
+    /// ReadWrite(original value, temporary stored value).
+    ///
+    /// Var has been read first and then written.
+    ///
+    /// It needs to be checked for consistency.
+    ReadWrite(ArcAny, ArcAny),
+
+    /// Var has been read on blocked path.
+    ///
+    /// Don't check for consistency, but block on Var,
+    /// so that the threat wakes up when the first path
+    /// has been unlocked.
+    ReadObsolete(ArcAny),
+
+    /// ReadWriteObsolete(original value, temporary stored value).
+    ///
+    /// Var has been read on blocked path and then written to.
+    ///
+    /// Don't check for consistency, but block on Var,
+    /// so that the threat wakes up when the first path
+    /// has been unlocked.
+    ReadObsoleteWrite(ArcAny, ArcAny), // Here would be WriteObsolete, but the write onlies can be discarded immediately
+                                       // and don't need a representation in the log.
+}
+
+impl LogVar {
+    /// Read a value and potentially upgrade the state.
+    pub fn read(&mut self) -> ArcAny {
+        // We do some kind of dance around the borrow checker here.
+        // Ideally we only clone the read value and not the write,
+        // in order to avoid hitting shared memory as least as possible,
+        // but we can not fully avoid it, although these cases happen rarely.
+        let this;
+        let val;
+        match &*self {
+            // Use last read value or get written one
+            &Self::Read(ref v) | &Self::Write(ref v) | &Self::ReadWrite(_, ref v) => {
+                return v.clone();
+            }
+
+            Self::ReadObsoleteWrite(w, v) => {
+                val = v.clone();
+                this = Self::ReadWrite(w.clone(), v.clone());
+            }
+
+            // Upgrade to a real Read
+            Self::ReadObsolete(v) => {
+                val = v.clone();
+                this = Self::Read(v.clone());
+            }
+        }
+        *self = this;
+        val
+    }
+
+    /// Write a value and potentially upgrade the state.
+    pub fn write(&mut self, w: ArcAny) {
+        let this = self.clone();
+
+        *self = match this {
+            Self::Write(_) => Self::Write(w),
+
+            // Register write
+            Self::ReadObsolete(r) | Self::ReadObsoleteWrite(r, _) => Self::ReadObsoleteWrite(r, w),
+
+            // Register write
+            Self::Read(r) | Self::ReadWrite(r, _) => Self::ReadWrite(r, w),
+        };
+    }
+
+    /// Turn `self` into an obsolete version.
+    pub fn obsolete(self) -> Option<LogVar> {
+        self.into_read_value().map(LogVar::ReadObsolete)
+    }
+
+    /// Ignore all Write... and get the original value of a Var.
+    pub fn into_read_value(self) -> Option<ArcAny> {
+        match self {
+            LogVar::Read(v)
+            | LogVar::ReadWrite(v, _)
+            | LogVar::ReadObsolete(v)
+            | LogVar::ReadObsoleteWrite(v, _) => Some(v),
+            LogVar::Write(_) => None,
+        }
+    }
+}
+
+/// Test if writes are ignored, when a var is set to obsolete.
+#[test]
+fn test_write_obsolete_ignore() {
+    let t = LogVar::Write(Arc::new(42)).obsolete();
+    assert!(t.is_none());
+}

--- a/light-stm/src/transaction/mod.rs
+++ b/light-stm/src/transaction/mod.rs
@@ -1,0 +1,451 @@
+pub mod log_var;
+
+use std::any::Any;
+use std::cell::Cell;
+// #[cfg(feature = "hash-registers")]
+// use std::collections::hash_map::Entry;
+// #[cfg(not(feature = "hash-registers"))]
+// use std::collections::{btree_map::Entry, BTreeMap};
+cfg_if::cfg_if! {
+    if #[cfg(feature = "hash-registers")] {
+        use std::collections::hash_map::Entry;
+    } else {
+        use std::collections::{btree_map::Entry, BTreeMap};
+    }
+}
+use std::mem;
+use std::sync::Arc;
+
+#[cfg(feature = "hash-registers")]
+use rustc_hash::FxHashMap;
+
+use crate::StmFallibleClosureResult;
+
+use self::log_var::LogVar;
+use super::result::{StmClosureResult, StmError};
+use super::tvar::{TVar, VarControlBlock};
+
+thread_local!(static TRANSACTION_RUNNING: Cell<bool> = const { Cell::new(false) });
+
+/// `TransactionGuard` checks against nested STM calls.
+///
+/// Use guard, so that it correctly marks the Transaction as finished.
+struct TransactionGuard;
+
+impl TransactionGuard {
+    pub fn new() -> TransactionGuard {
+        TRANSACTION_RUNNING.with(|t| {
+            assert!(!t.get(), "STM: Nested Transaction");
+            t.set(true);
+        });
+        TransactionGuard
+    }
+}
+
+impl Drop for TransactionGuard {
+    fn drop(&mut self) {
+        TRANSACTION_RUNNING.with(|t| {
+            t.set(false);
+        });
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransactionControl {
+    Retry,
+    Abort,
+}
+
+/// Transaction tracks all the read and written variables.
+///
+/// It is used for checking vars, to ensure atomicity.
+pub struct Transaction {
+    /// Map of all vars that map the `VarControlBlock` of a var to a `LogVar`.
+    /// The `VarControlBlock` is unique because it uses it's address for comparing.
+    ///
+    /// The logs need to be accessed in a order to prevend dead-locks on locking.
+    #[cfg(not(feature = "hash-registers"))]
+    vars: BTreeMap<Arc<VarControlBlock>, LogVar>,
+    #[cfg(feature = "hash-registers")]
+    vars: FxHashMap<*const VarControlBlock, LogVar>,
+}
+
+impl Transaction {
+    /// Create a new log.
+    ///
+    /// Normally you don't need to call this directly.
+    /// Use `atomically` instead.
+    fn new() -> Transaction {
+        Transaction {
+            #[cfg(not(feature = "hash-registers"))]
+            vars: BTreeMap::new(),
+            #[cfg(feature = "hash-registers")]
+            vars: FxHashMap::default(),
+        }
+    }
+
+    /// Run a function with a transaction.
+    ///
+    /// It is equivalent to `atomically`.
+    pub fn with<T, F>(f: F) -> T
+    where
+        F: Fn(&mut Transaction) -> StmClosureResult<T>,
+    {
+        let _guard = TransactionGuard::new();
+
+        // create a log guard for initializing and cleaning up
+        // the log
+        let mut transaction = Transaction::new();
+
+        // loop until success
+        loop {
+            // run the computation
+            if let Ok(t) = f(&mut transaction) {
+                if transaction.commit() {
+                    return t;
+                }
+            }
+
+            // clear log before retrying computation
+            transaction.clear();
+        }
+    }
+
+    /// Run a function with a transaction.
+    ///
+    /// The transaction will be retried until:
+    /// - it is validated, or
+    /// - it is explicitly aborted from the function, using the `abort` function.
+    pub fn with_err<T, F, E>(f: F) -> Result<T, E>
+    where
+        F: Fn(&mut Transaction) -> StmFallibleClosureResult<T, E>,
+    {
+        let _guard = TransactionGuard::new();
+
+        // create a log guard for initializing and cleaning up
+        // the log
+        let mut transaction = Transaction::new();
+
+        // loop until success
+        loop {
+            // run the computation
+            match f(&mut transaction) {
+                // on success exit loop
+                Ok(t) => {
+                    if transaction.commit() {
+                        return Ok(t);
+                    }
+                }
+                // on error,
+                Err(e) => match e {
+                    // abort and return the error
+                    StmError::Abort(err) => return Err(err.0),
+                    // retry
+                    StmError::Retry(_) => {}
+                },
+            }
+
+            // clear log before retrying computation
+            transaction.clear();
+        }
+    }
+
+    #[allow(clippy::needless_pass_by_value)]
+    /// Perform a downcast on a var.
+    fn downcast<T: Any + Clone>(var: Arc<dyn Any>) -> T {
+        match var.downcast_ref::<T>() {
+            Some(s) => s.clone(),
+            None => unreachable!("TVar has wrong type"),
+        }
+    }
+
+    /// Read a variable and return the value.
+    ///
+    /// The returned value is not always consistent with the current value of the var,
+    /// but may be an outdated or or not yet commited value.
+    ///
+    /// The used code should be capable of handling inconsistent states
+    /// without running into infinite loops.
+    /// Just the commit of wrong values is prevented by STM.
+    pub fn read<T: Send + Sync + Any + Clone>(&mut self, var: &TVar<T>) -> T {
+        let ctrl = var.control_block().clone();
+        // Check if the same var was written before.
+        #[cfg(not(feature = "hash-registers"))]
+        let key = ctrl;
+        #[cfg(feature = "hash-registers")]
+        let key = Arc::as_ptr(&ctrl);
+        let value = match self.vars.entry(key) {
+            // If the variable has been accessed before, then load that value.
+            Entry::Occupied(mut entry) => entry.get_mut().read(),
+
+            // Else load the variable statically.
+            Entry::Vacant(entry) => {
+                // Read the value from the var.
+                let value = var.read_ref_atomic();
+
+                // Store in in an entry.
+                entry.insert(LogVar::Read(value.clone()));
+                value
+            }
+        };
+
+        Transaction::downcast(value)
+    }
+
+    /// Write a variable.
+    ///
+    /// The write is not immediately visible to other threads,
+    /// but atomically commited at the end of the computation.
+    pub fn write<T: Any + Send + Sync + Clone>(&mut self, var: &TVar<T>, value: T) {
+        // box the value
+        let boxed = Arc::new(value);
+
+        // new control block
+        let ctrl = var.control_block().clone();
+        // update or create new entry
+        #[cfg(not(feature = "hash-registers"))]
+        let key = ctrl;
+        #[cfg(feature = "hash-registers")]
+        let key = Arc::as_ptr(&ctrl);
+        match self.vars.entry(key) {
+            Entry::Occupied(mut entry) => entry.get_mut().write(boxed),
+            Entry::Vacant(entry) => {
+                entry.insert(LogVar::Write(boxed));
+            }
+        }
+    }
+
+    /// Combine two calculations. When one blocks with `retry`,
+    /// run the other, but don't commit the changes in the first.
+    ///
+    /// If both block, `Transaction::or` still waits for `TVar`s in both functions.
+    /// Use `Transaction::or` instead of handling errors directly with the `Result::or`.
+    /// The later does not handle all the blocking correctly.
+    pub fn or<T, F1, F2>(&mut self, first: F1, second: F2) -> StmClosureResult<T>
+    where
+        F1: Fn(&mut Transaction) -> StmClosureResult<T>,
+        F2: Fn(&mut Transaction) -> StmClosureResult<T>,
+    {
+        // Create a backup of the log.
+        let mut copy = Transaction {
+            vars: self.vars.clone(),
+        };
+
+        // Run the first computation.
+        let f = first(self);
+
+        match f {
+            // Run other on manual retry call.
+            Err(_) => {
+                // swap, so that self is the current run
+                mem::swap(self, &mut copy);
+
+                // Run other action.
+                let s = second(self);
+                self.combine(copy);
+                s
+            }
+
+            // Return success and failure directly
+            x => x,
+        }
+    }
+
+    /// Combine two logs into a single log, to allow waiting for all reads.
+    fn combine(&mut self, other: Transaction) {
+        // combine reads
+        for (var, value) in other.vars {
+            // only insert new values
+            if let Some(value) = value.obsolete() {
+                self.vars.entry(var).or_insert(value);
+            }
+        }
+    }
+
+    /// Clear the log's data.
+    ///
+    /// This should be used before redoing a computation, but
+    /// nowhere else.
+    fn clear(&mut self) {
+        self.vars.clear();
+    }
+
+    /// Write the log back to the variables.
+    ///
+    /// Return true for success and false, if a read var has changed
+    fn commit(&mut self) -> bool {
+        // Use two phase locking for safely writing data back to the vars.
+
+        // First phase: acquire locks.
+        // Check for consistency of all the reads and perform
+        // an early return if something is not consistent.
+
+        // Created arrays for storing the locks
+        // vector of locks.
+        let mut read_vec = Vec::with_capacity(self.vars.len());
+
+        // vector of tuple (value, lock)
+        let mut write_vec = Vec::with_capacity(self.vars.len());
+
+        // vector of written variables
+        let mut written = Vec::with_capacity(self.vars.len());
+
+        #[cfg(feature = "hash-registers")]
+        let records = {
+            let mut recs: Vec<_> = self.vars.iter().collect();
+            recs.sort_by(|(k1, _), (k2, _)| k1.cmp(&k2));
+            recs
+        };
+        #[cfg(not(feature = "hash-registers"))]
+        let records = &self.vars;
+
+        for (var, value) in records {
+            // lock the variable and read the value
+            #[cfg(feature = "hash-registers")]
+            let var = unsafe { var.as_ref() }.expect("E: unreachabel");
+
+            match *value {
+                // We need to take a write lock.
+                LogVar::Write(ref w) | LogVar::ReadObsoleteWrite(_, ref w) => {
+                    // take write lock
+                    let lock = var.value.write();
+                    // add all data to the vector
+                    write_vec.push((w, lock));
+                    written.push(var);
+                }
+
+                // We need to check for consistency and
+                // take a write lock.
+                LogVar::ReadWrite(ref original, ref w) => {
+                    // take write lock
+                    let lock = var.value.write();
+
+                    if !Arc::ptr_eq(&lock, original) {
+                        return false;
+                    }
+                    // add all data to the vector
+                    write_vec.push((w, lock));
+                    written.push(var);
+                }
+                // Nothing to do. ReadObsolete is only needed for blocking, not
+                // for consistency checks.
+                LogVar::ReadObsolete(_) => {}
+                // Take read lock and check for consistency.
+                LogVar::Read(ref original) => {
+                    // Take a read lock.
+                    let lock = var.value.read();
+
+                    if !Arc::ptr_eq(&lock, original) {
+                        return false;
+                    }
+
+                    read_vec.push(lock);
+                }
+            }
+        }
+
+        // Second phase: write back and release
+
+        // Release the reads first.
+        // This allows other threads to continue quickly.
+        drop(read_vec);
+
+        for (value, mut lock) in write_vec {
+            // Commit value.
+            *lock = value.clone();
+        }
+
+        // Commit succeded.
+        true
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn read() {
+        let mut log = Transaction::new();
+        let var = TVar::new(vec![1, 2, 3, 4]);
+
+        // The variable can be read.
+        assert_eq!(&*log.read(&var), &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn write_read() {
+        let mut log = Transaction::new();
+        let var = TVar::new(vec![1, 2]);
+
+        log.write(&var, vec![1, 2, 3, 4]);
+
+        // Consecutive reads get the updated version.
+        assert_eq!(log.read(&var), [1, 2, 3, 4]);
+
+        // The original value is still preserved.
+        assert_eq!(var.read_atomic(), [1, 2]);
+    }
+
+    #[test]
+    fn transaction_simple() {
+        let x = Transaction::with(|_| Ok(42));
+        assert_eq!(x, 42);
+    }
+
+    #[test]
+    fn transaction_read() {
+        let read = TVar::new(42);
+
+        let x = Transaction::with(|trans| Ok(read.read(trans)));
+
+        assert_eq!(x, 42);
+    }
+
+    #[test]
+    fn transaction_write() {
+        let write = TVar::new(42);
+
+        Transaction::with(|trans| Ok(write.write(trans, 0)));
+
+        assert_eq!(write.read_atomic(), 0);
+    }
+
+    #[test]
+    fn transaction_copy() {
+        let read = TVar::new(42);
+        let write = TVar::new(0);
+
+        Transaction::with(|trans| {
+            let r = read.read(trans);
+            write.write(trans, r);
+            Ok(())
+        });
+
+        assert_eq!(write.read_atomic(), 42);
+    }
+
+    // Dat name. seriously?
+    #[test]
+    fn transaction_control_stuff() {
+        let read = TVar::new(42);
+        let write = TVar::new(0);
+
+        Transaction::with(|trans| {
+            let r = read.read(trans);
+            write.write(trans, r);
+            Ok(())
+        });
+
+        assert_eq!(write.read_atomic(), 42);
+    }
+
+    /// Test if nested transactions are correctly detected.
+    #[test]
+    #[should_panic]
+    fn transaction_nested_fail() {
+        Transaction::with(|_| {
+            Transaction::with(|_| Ok(42));
+            Ok(1)
+        });
+    }
+}

--- a/light-stm/src/tvar.rs
+++ b/light-stm/src/tvar.rs
@@ -1,0 +1,237 @@
+// Copyright 2015-2016 rust-stm Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use parking_lot::RwLock;
+use std::any::Any;
+use std::cmp;
+use std::fmt::{self, Debug};
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use super::Transaction;
+
+/// `VarControlBlock` contains all the useful data for a `Var` while beeing the same type.
+///
+/// The control block is accessed from other threads directly whereas `Var`
+/// is just a typesafe wrapper around it.
+pub struct VarControlBlock {
+    /// The inner value of the Var.
+    ///
+    /// It can be shared through a Arc without copying it too often.
+    ///
+    /// The Arc is also used by the threads to detect changes.
+    /// The value in it should not be changed or locked because
+    /// that may cause multiple threads to block unforeseen as well as
+    /// causing deadlocks.
+    ///
+    /// The shared reference is protected by a `RWLock` so that multiple
+    /// threads can safely block it. This ensures consistency, without
+    /// preventing other threads from accessing the values.
+    ///
+    /// Starvation may occur, if one thread wants to write-lock but others
+    /// keep holding read-locks.
+    pub value: RwLock<Arc<dyn Any + Send + Sync>>,
+}
+
+impl VarControlBlock {
+    /// create a new empty `VarControlBlock`
+    pub fn new<T>(val: T) -> Arc<VarControlBlock>
+    where
+        T: Any + Sync + Send,
+    {
+        let ctrl = VarControlBlock {
+            value: RwLock::new(Arc::new(val)),
+        };
+        Arc::new(ctrl)
+    }
+
+    fn get_address(&self) -> usize {
+        std::ptr::from_ref::<VarControlBlock>(self) as usize
+    }
+}
+
+// Implement some operators so that VarControlBlocks can be sorted.
+
+impl PartialEq for VarControlBlock {
+    fn eq(&self, other: &Self) -> bool {
+        self.get_address() == other.get_address()
+    }
+}
+
+impl Eq for VarControlBlock {}
+
+impl Ord for VarControlBlock {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.get_address().cmp(&other.get_address())
+    }
+}
+
+impl PartialOrd for VarControlBlock {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// A variable that can be used in a STM-Block
+#[derive(Clone)]
+pub struct TVar<T> {
+    /// The control block is the inner of the variable.
+    ///
+    /// The rest of `TVar` is just the typesafe interface.
+    control_block: Arc<VarControlBlock>,
+
+    /// This marker is needed so that the variable can be used in a typesafe
+    /// manner.
+    _marker: PhantomData<T>,
+}
+
+impl<T> TVar<T>
+where
+    T: Any + Sync + Send + Clone,
+{
+    /// Create a new `TVar`.
+    pub fn new(val: T) -> TVar<T> {
+        TVar {
+            control_block: VarControlBlock::new(val),
+            _marker: PhantomData,
+        }
+    }
+
+    #[allow(clippy::missing_panics_doc)]
+    /// `read_atomic` reads a value atomically, without starting a transaction.
+    ///
+    /// It is semantically equivalent to
+    ///
+    /// ```
+    /// # use fast_stm::*;
+    ///
+    /// let var = TVar::new(0);
+    /// atomically(|trans| var.read(trans));
+    /// ```
+    ///
+    /// but more efficient.
+    ///
+    /// `read_atomic` returns a clone of the value.
+    pub fn read_atomic(&self) -> T {
+        let val = self.read_ref_atomic();
+
+        (&*val as &dyn Any)
+            .downcast_ref::<T>()
+            .expect("wrong type in Var<T>")
+            .clone()
+    }
+
+    /// Read a value atomically but return a reference.
+    ///
+    /// This is mostly used internally, but can be useful in
+    /// some cases, because `read_atomic` clones the
+    /// inner value, which may be expensive.
+    pub fn read_ref_atomic(&self) -> Arc<dyn Any + Send + Sync> {
+        self.control_block.value.read().clone()
+    }
+
+    /// The normal way to access a var.
+    ///
+    /// It is equivalent to `transaction.read(&var)`, but more
+    /// convenient.
+    pub fn read(&self, transaction: &mut Transaction) -> T {
+        transaction.read(self)
+    }
+
+    /// The normal way to write a var.
+    ///
+    /// It is equivalent to `transaction.write(&var, value)`, but more
+    /// convenient.
+    pub fn write(&self, transaction: &mut Transaction, value: T) {
+        transaction.write(self, value);
+    }
+
+    /// Modify the content of a `TVar` with the function f.
+    ///
+    /// ```
+    /// # use fast_stm::*;
+    ///
+    ///
+    /// let var = TVar::new(21);
+    /// atomically(|trans|
+    ///     var.modify(trans, |x| x*2)
+    /// );
+    ///
+    /// assert_eq!(var.read_atomic(), 42);
+    /// ```
+    pub fn modify<F>(&self, transaction: &mut Transaction, f: F)
+    where
+        F: FnOnce(T) -> T,
+    {
+        let old = self.read(transaction);
+        self.write(transaction, f(old));
+    }
+
+    /// Replaces the value of a `TVar` with a new one, returning
+    /// the old one.
+    ///
+    /// ```
+    /// # use fast_stm::*;
+    ///
+    /// let var = TVar::new(0);
+    /// let x = atomically(|trans|
+    ///     var.replace(trans, 42)
+    /// );
+    ///
+    /// assert_eq!(x, 0);
+    /// assert_eq!(var.read_atomic(), 42);
+    /// ```
+    pub fn replace(&self, transaction: &mut Transaction, value: T) -> T {
+        let old = self.read(transaction);
+        self.write(transaction, value);
+        old
+    }
+
+    /// Check if two `TVar`s refer to the same position.
+    pub fn ref_eq(this: &TVar<T>, other: &TVar<T>) -> bool {
+        Arc::ptr_eq(&this.control_block, &other.control_block)
+    }
+
+    /// Access the control block of the var.
+    ///
+    /// Internal use only!
+    pub(crate) fn control_block(&self) -> &Arc<VarControlBlock> {
+        &self.control_block
+    }
+}
+
+/// Debug output a struct.
+///
+/// Note that this function does not print the state atomically.
+/// If another thread modifies the datastructure at the same time, it may print an inconsistent state.
+/// If you need an accurate view, that reflects current thread-local state, you can implement it easily yourself with
+/// atomically.
+///
+/// Running `atomically` inside a running transaction panics. Therefore `fmt` uses
+/// prints the state.
+impl<T> Debug for TVar<T>
+where
+    T: Any + Sync + Send + Clone,
+    T: Debug,
+{
+    #[inline(never)]
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        let x = self.read_atomic();
+        f.debug_struct("TVar").field("value", &x).finish()
+    }
+}
+
+#[test]
+// Test if creating and reading a TVar works.
+fn test_read_atomic() {
+    let var = TVar::new(42);
+
+    assert_eq!(42, var.read_atomic());
+}
+
+// More tests are in lib.rs.


### PR DESCRIPTION
This contains a minimal waitless retry + no early check implementation. Most notably, a lot of `Result`s can be removed from the API.