### PR TITLE
refactor!: rename `TVar::replace` to `TVar::exchange`

### DIFF
--- a/fast-stm/src/transaction/mod.rs
+++ b/fast-stm/src/transaction/mod.rs
@@ -746,13 +746,13 @@ impl Transaction {
         Ok(())
     }
 
-    /// Replace a variable.
+    /// Replace a variable, returning the old value.
     ///
     /// The write is not immediately visible to other threads,
     /// but atomically commited at the end of the computation.
     ///
     /// Prefer this method over calling `read` then `write` for performance.
-    pub fn replace<T: Any + Send + Sync + Clone>(
+    pub fn exchange<T: Any + Send + Sync + Clone>(
         &mut self,
         var: &TVar<T>,
         value: T,

--- a/fast-stm/src/tvar.rs
+++ b/fast-stm/src/tvar.rs
@@ -308,8 +308,8 @@ where
     /// assert_eq!(x, 0);
     /// assert_eq!(var.read_atomic(), 42);
     /// ```
-    pub fn replace(&self, transaction: &mut Transaction, value: T) -> StmClosureResult<T> {
-        transaction.replace(self, value)
+    pub fn exchange(&self, transaction: &mut Transaction, value: T) -> StmClosureResult<T> {
+        transaction.exchange(self, value)
     }
 
     /// Check if two `TVar`s refer to the same position.


### PR DESCRIPTION
from https://github.com/LIHPC-Computational-Geometry/honeycomb/pull/445#pullrequestreview-3934811083:

> In C++ `std::atomic`, the name if `exchange` (https://en.cppreference.com/w/cpp/atomic/atomic/exchange.html), in Rust's atomic it is `swap` but the `compare_` version is `compare_exchange`.

given that Rust's `compare_and_swap` is deprecated, I'm assuming they are moving towards the same naming as C++, so I called it `exchange`.