### PR TITLE
feat(bench): add `RwLock` to read/write time micro-benchmarks

### DIFF
--- a/benches/benches/read.rs
+++ b/benches/benches/read.rs
@@ -1,5 +1,6 @@
 use std::hint::black_box;
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::RwLock;
 
 use criterion::{
     criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion, PlotConfiguration,
@@ -31,6 +32,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     // G1
     let tvar = TVar::new(42_u32);
     let atom = AtomicU32::new(42);
+    let lock = RwLock::new(42_u32);
 
     let mut g1 = c.benchmark_group("read-times");
 
@@ -46,6 +48,12 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     });
     g1.bench_function("AtomicU32::load", |b| {
         b.iter(|| black_box(atom.load(Ordering::Relaxed)))
+    });
+    g1.bench_function("RwLock::read", |b| {
+        b.iter(|| {
+            let res = lock.read().unwrap();
+            black_box(*res)
+        })
     });
     g1.finish();
 

--- a/benches/benches/write.rs
+++ b/benches/benches/write.rs
@@ -1,5 +1,6 @@
 use std::hint::black_box;
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::RwLock;
 
 use criterion::{
     criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion, PlotConfiguration,
@@ -50,6 +51,13 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     g1.bench_function("AtomicU32::store", |b| {
         let atom = AtomicU32::new(old_value);
         b.iter(|| black_box(atom.store(new_value, Ordering::Relaxed)))
+    });
+    g1.bench_function("RwLock::write", |b| {
+        let lock = RwLock::new(old_value);
+        b.iter(|| {
+            let mut res = lock.write().unwrap();
+            *res = new_value;
+        })
     });
 
     g1.finish();


### PR DESCRIPTION
add `RwLock` to the list of compared structs for the read and write time benchmarks