### PR TITLE
fix: `TVar::replace` and `TVar::modify` insert a read-write log in transaction registers

### DIFF
--- a/fast-stm/src/transaction/mod.rs
+++ b/fast-stm/src/transaction/mod.rs
@@ -736,9 +736,9 @@ impl Transaction {
             }
             Entry::Vacant(entry) => {
                 // Read the value from the var.
-                let value = Transaction::downcast(var.read_ref_atomic());
-                let boxed = Arc::new(f(value));
-                entry.insert(LogVar::Write(boxed));
+                let value = var.read_ref_atomic();
+                let boxed = Arc::new(f(Transaction::downcast(value.clone())));
+                entry.insert(LogVar::ReadWrite(value, boxed));
             }
         }
 
@@ -820,7 +820,7 @@ impl Transaction {
             Entry::Vacant(entry) => {
                 // Read the value from the var.
                 let value = var.read_ref_atomic();
-                entry.insert(LogVar::Write(boxed));
+                entry.insert(LogVar::ReadWrite(value.clone(), boxed));
                 value
             }
         };

--- a/fast-stm/src/tvar.rs
+++ b/fast-stm/src/tvar.rs
@@ -302,7 +302,7 @@ where
     ///
     /// let var = TVar::new(0);
     /// let x = atomically(|trans|
-    ///     var.replace(trans, 42)
+    ///     var.exchange(trans, 42)
     /// );
     ///
     /// assert_eq!(x, 0);


### PR DESCRIPTION
closes #33 